### PR TITLE
Switch trifecta to megaparsec

### DIFF
--- a/hpack-dhall.cabal
+++ b/hpack-dhall.cabal
@@ -1,8 +1,8 @@
--- This file has been generated from package.dhall by hpack version 0.26.0.
+-- This file has been generated from package.dhall by hpack version 0.28.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f761e67d74579bbbdc1341aa931460abda1791c20612594271e79b5164f3e21f
+-- hash: 850524cb98d0e828b19d73102519d293c4c82b4afb077a006120e7f9039e4374
 
 name:           hpack-dhall
 version:        0.1.0
@@ -35,9 +35,9 @@ executable hpack-dhall
     , dhall
     , dhall-json
     , hpack >=0.26.0
+    , megaparsec
     , text
     , transformers
-    , trifecta
   default-language: Haskell2010
 
 test-suite spec
@@ -59,8 +59,8 @@ test-suite spec
     , hpack >=0.26.0
     , hspec ==2.*
     , interpolate
+    , megaparsec
     , mockery
     , text
     , transformers
-    , trifecta
   default-language: Haskell2010

--- a/package.dhall
+++ b/package.dhall
@@ -12,7 +12,7 @@
 
 , dependencies = [
     "base == 4.*"
-  , "trifecta"
+  , "megaparsec"
   , "dhall"
   , "dhall-json"
   , "hpack >= 0.26.0"

--- a/package.yaml
+++ b/package.yaml
@@ -12,7 +12,7 @@ ghc-options: -Wall
 
 dependencies:
   - base == 4.*
-  - trifecta
+  - megaparsec
   - dhall
   - dhall-json
   - hpack >= 0.26.0

--- a/src/Hpack/Dhall.hs
+++ b/src/Hpack/Dhall.hs
@@ -7,10 +7,7 @@ import           Control.Monad.IO.Class
 import           Data.Bifunctor
 import           Data.Aeson
 import qualified Data.Text.Lazy.IO as LT
-import qualified Data.Text as T
-import           Data.Text.Encoding (encodeUtf8)
 import           System.Environment
-import           Text.Trifecta.Delta (Delta(..))
 import qualified Dhall.Parser
 import qualified Dhall.Import
 import qualified Dhall.TypeCheck
@@ -28,7 +25,7 @@ decodeDhall file = runExceptT $ do
   liftResult $ Dhall.JSON.dhallToJSON expr
   where
     readInput = liftIO (LT.readFile file)
-    parseExpr = liftResult . Dhall.Parser.exprFromText (Directed (encodeUtf8 $ T.pack file) 0 0 0 0)
+    parseExpr = liftResult . Dhall.Parser.exprFromText file
     liftResult = ExceptT . return . first show
 
 main :: IO ()


### PR DESCRIPTION
Dhall switched from `trifecta` to `megaparsec` in https://github.com/dhall-lang/dhall-haskell/pull/268.

This PR does the same switch and fixes compilation.

I was unable to get the tests to run, but running `hpack-dhall` on `package.dhall` seems to give the correct output.